### PR TITLE
Pin mediapipe dependency to 0.10.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "numpy",
         "opencv-python",
-        "mediapipe",
+        "mediapipe==0.10.21",
         "scipy",
         "pyrealsense2",
         "pyspacemouse",


### PR DESCRIPTION
## Summary

This PR fixes an installation and runtime issue caused by an unpinned `mediapipe` dependency.

## Details

- `setup.py` previously allowed installing the latest mediapipe versions by default
- Starting from mediapipe `0.10.30`, several Python APIs and internal modules used by telemoma were removed or refactored
- This leads to runtime errors after installation
- mediapipe `0.10.21` has been verified to work correctly with the current codebase

This PR pins mediapipe to `0.10.21` to ensure compatibility and reproducibility.

## Changes

- Pin `mediapipe==0.10.21` in `setup.py`

## Related issue

Fixes #5